### PR TITLE
Fix lint error in tests

### DIFF
--- a/test/dev-env-stack.test.ts
+++ b/test/dev-env-stack.test.ts
@@ -63,6 +63,7 @@ afterAll(() => {
 class MockBucket implements IBucket {
   public bucketName = 'mock-bucket';
   public arnForObjects(_pattern: string) {
+    void _pattern; // avoid unused param lint error
     return 'arn:aws:s3:::mock-bucket/*';
   }
   // ...必要なメソッドだけ実装（最低限）...


### PR DESCRIPTION
## Summary
- silence unused parameter warning for MockBucket

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841125c7a9c8333be200d3cbfaa3e96